### PR TITLE
ユーザ情報を返す時、セキュリティを考慮してパスワードは返さないように修正

### DIFF
--- a/domain/service/getAllUser.go
+++ b/domain/service/getAllUser.go
@@ -12,5 +12,10 @@ func (u *userServiceStruct) FindAllUsersService() ([]model.User, error) {
 	if err != nil {
 		log.Println(err)
 	}
+	// セキュリティのためパスワードを返さない
+	for i := 0; i < len(users); i++ {
+		users[i].Password = ""
+	}
+
 	return users, err
 }

--- a/domain/service/getUserFindByUserId.go
+++ b/domain/service/getUserFindByUserId.go
@@ -12,5 +12,8 @@ func (u *userServiceStruct) FindUserByUserIdService(userId int) (model.User, err
 	if err != nil {
 		log.Println(err)
 	}
+	// セキュリティのためパスワードを返さない
+	user.Password = ""
+
 	return user, err
 }


### PR DESCRIPTION
## 内容
user(users)のパスワードの中身を空にした

## 確認手順
1. パスワード情報を保持しないユーザを返す
```
$ curl -s -X GET \
  --url 'localhost:1454/user/[ユーザID]'
```

2. パスワード情報を保持しない全ユーザを返す
```
$ curl -s -X GET \
  --url 'localhost:1454/users'
```